### PR TITLE
Add first_display column to host table

### DIFF
--- a/core/migrations/Migration20180703151011ComTools
+++ b/core/migrations/Migration20180703151011ComTools
@@ -1,0 +1,35 @@
+<?php
+
+use Hubzero\Content\Migration\Base;
+
+/**
+ * Migration script for com_tools to specify display ranges assigned to a hub.  
+ **/
+class Migration20180703151011ComTools extends Base
+{
+	/**
+	 * Up
+	 **/
+	public function up()
+	{
+               // ADD COLUMN first_display to table host
+                if ($this->db->tableExists('host') && !$this->db->tableHasField('host', 'first_display')) {
+                        $query = "ALTER TABLE host ADD COLUMN first_display INT DEFAULT 1;";
+                        $this->db->setQuery($query);
+                        $this->db->query();
+                }
+	}
+
+	/**
+	 * Down
+	 **/
+	public function down()
+	{
+                // Drop column first_display
+                if ($this->db->tableExists('host') && $this->db->tableHasField('host', 'first_display')) {
+                        $query = "ALTER TABLE host DROP COLUMN first_display;";
+                        $this->db->setQuery($query);
+                        $this->db->query();
+                }
+	}
+}


### PR DESCRIPTION
Each middleware client should be using a different range of displays (container IDs), so that multiple hubs can use the same execution host.  The range is from first_display to (first_display + max_uses -1 )